### PR TITLE
GUI: Support dragging and dropping folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ While `festival-gui` is the only `Frontend` available, the changelog and release
 
 
 # Unreleased
+## Added
+* Drag-and-drop support for `Collection` folders ([#51](https://github.com/hinto-janai/festival/pull/51)
 
 
 ---

--- a/gui/src/func/init.rs
+++ b/gui/src/func/init.rs
@@ -137,6 +137,7 @@ impl crate::data::Gui {
 			initial_window_size: Some(egui::vec2(APP_WIDTH_DEFAULT, APP_HEIGHT_DEFAULT)),
 			follow_system_theme: false,
 			default_theme: eframe::Theme::Dark,
+			drag_and_drop_support: true,
 			// FIXME:
 			// `eframe::Renderer::Wgpu` causes colors to
 			// be over-saturated on `KDE`. For now, use

--- a/gui/src/text.rs
+++ b/gui/src/text.rs
@@ -214,6 +214,14 @@ pub const SEARCH_SORT_SONG:        &str = "Search by song title";
 pub const SEARCH_SORT_ALBUM:       &str = "Search by album title";
 pub const SEARCH_SORT_ARTIST:      &str = "Search by artist name";
 
+//---------------------------------------------------------------------------------------------------- Misc
+pub const DRAG_AND_DROP: &str =
+r#"🗁
+
+Or drag and drop a folder anywhere in
+
+Festival to start scanning it."#;
+
 //---------------------------------------------------------------------------------------------------- TESTS
 //#[cfg(test)]
 //mod tests {

--- a/gui/src/ui/update.rs
+++ b/gui/src/ui/update.rs
@@ -51,7 +51,7 @@ use crate::constants::{
 	RUNTIME_WIDTH,
 };
 use crate::text::{
-	HELP,MOD,
+	HELP,MOD,DRAG_AND_DROP,
 	EMPTY_COLLECTION,
 	COLLECTION_LOADING,
 	COLLECTION_RESETTING,
@@ -786,16 +786,15 @@ fn show_empty_collection(&mut self, ui: &mut egui::Ui, ctx: &egui::Context, widt
 	let height = height / 10.0;
 
 	ui.vertical_centered(|ui| {
-		let space = height / 2.0;
-		ui.add_space(space);
+		ui.add_space(height / 2.0);
 
 		if ui.add_sized([width, height], button).on_hover_text(EMPTY_COLLECTION).clicked() {
 			self.reset_collection();
 		}
 
-		ui.add_space(space);
+		ui.add_space(ui.available_height() / 3.0);
 
-		ui.label(HELP);
+		ui.label(DRAG_AND_DROP);
 	});
 }}
 


### PR DESCRIPTION
This PR will enable dragging folders into Festival to add to the `Collection` folder list.

Behavior:
- If folder, add
- If file, add parent folder
- If empty `Collection`, drag-and-drop should start reset