### PR TITLE
Restore `AudioState` after `Collection` reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Types of changes:
 ## Added
 * Playlists ([#58](https://github.com/hinto-janai/festival/pull/58))
 * Drag-and-drop support for `Collection` folders ([#51](https://github.com/hinto-janai/festival/pull/51))
+* Audio state now recovers (as much as possible) across `Collection` resets ([#59](https://github.com/hinto-janai/festival/pull/59))
 * Key-binding for adding songs/albums/artists to playlists - `CTRL + Primary Mouse`
 
 ## Changed

--- a/gui/src/func/gui.rs
+++ b/gui/src/func/gui.rs
@@ -21,7 +21,7 @@ use shukusai::{
 	collection::{
 		Collection,
 	},
-	state::PLAYLISTS,
+	state::{AUDIO_STATE,PLAYLISTS},
 	constants::PLAYLIST_VERSION,
 };
 use benri::{
@@ -82,6 +82,9 @@ impl Gui {
 
 		// Update playlist.
 		self.og_playlists = PLAYLISTS.read().clone();
+
+		// Update audio state.
+		self.audio_state = AUDIO_STATE.read().clone();
 	}
 
 	// Sets the [`egui::Ui`]'s `Visual` from our current `Settings`
@@ -242,7 +245,6 @@ impl Gui {
 
 		// Go into collection mode.
 		self.resetting_collection = true;
-
 	}
 
 	/// Caches some segments of [`Collection`] for local use

--- a/shukusai/src/collection/map.rs
+++ b/shukusai/src/collection/map.rs
@@ -12,6 +12,15 @@ use crate::collection::{
 };
 use std::sync::Arc;
 
+//---------------------------------------------------------------------------------------------------- MapEntry
+#[derive(Clone,Debug,Default,PartialEq,Encode,Decode)]
+/// An absolute "Key" for the [`Map`].
+pub struct MapKey {
+	pub artist: Arc<str>,
+	pub album: Arc<str>,
+	pub song: Arc<str>,
+}
+
 //---------------------------------------------------------------------------------------------------- Map
 #[derive(Clone,Debug,Default,PartialEq,Encode,Decode)]
 /// A [`HashMap`] that knows all [`Artist`]'s, [`Album`]'s and [`Song`]'s.

--- a/shukusai/src/collection/map.rs
+++ b/shukusai/src/collection/map.rs
@@ -3,6 +3,7 @@ use serde::{Serialize,Deserialize};
 use bincode::{Encode,Decode};
 use std::collections::HashMap;
 use crate::collection::{
+	Collection,
 	Artist,
 	Album,
 	Song,
@@ -13,12 +14,45 @@ use crate::collection::{
 use std::sync::Arc;
 
 //---------------------------------------------------------------------------------------------------- MapEntry
-#[derive(Clone,Debug,Default,PartialEq,Encode,Decode)]
+#[derive(Clone,Debug,PartialEq,Serialize,Deserialize,Encode,Decode)]
 /// An absolute "Key" for the [`Map`].
 pub struct MapKey {
+	/// Artist name
 	pub artist: Arc<str>,
+	/// Album title
 	pub album: Arc<str>,
+	/// Song title
 	pub song: Arc<str>,
+}
+
+impl MapKey {
+	/// Create `self` by walking a `Song`.
+	pub fn from_song(song: &Song, collection: &Arc<Collection>) -> Self {
+		let album  = &collection.albums[song.album];
+		let artist = &collection.artists[album.artist];
+		Self {
+			artist: Arc::clone(&artist.name),
+			album: Arc::clone(&album.title),
+			song: Arc::clone(&song.title),
+		}
+	}
+
+	/// INVARIANT: assumes key is valid
+	///
+	/// Create `self` by walking a `SongKey`.
+	pub fn from_song_key(key: SongKey, collection: &Arc<Collection>) -> Self {
+		let (artist, album, song) = collection.walk(key);
+		Self {
+			artist: Arc::clone(&artist.name),
+			album: Arc::clone(&album.title),
+			song: Arc::clone(&song.title),
+		}
+	}
+
+	/// Attempts to look in the `Collection` for 100% matching `Song`.
+	pub fn to_key(&self, collection: &Arc<Collection>) -> Option<SongKey> {
+		collection.song(&*self.artist, &*self.album, &*self.song).map(|(s, _)| s.key)
+	}
 }
 
 //---------------------------------------------------------------------------------------------------- Map

--- a/shukusai/src/state/audio.rs
+++ b/shukusai/src/state/audio.rs
@@ -2,7 +2,7 @@
 use serde::{Serialize,Deserialize};
 use bincode::{Encode,Decode};
 use crate::collection::{
-	SongKey,
+	SongKey,MapKey,
 };
 use crate::constants::{
 	HEADER,AUDIO_VERSION,
@@ -187,6 +187,18 @@ impl Default for AudioState {
 	fn default() -> Self {
 		Self::new()
 	}
+}
+
+//---------------------------------------------------------------------------------------------------- AudioStateRestore
+pub struct AudioStateRestore {
+	pub queue: VecDeque<MapKey>,
+	pub queue_idx: Option<usize>,
+	pub playing: bool,
+	pub song: Option<MapKey>,
+	pub elapsed: Runtime,
+	pub runtime: Runtime,
+	pub repeat: Repeat,
+	pub volume: Volume,
 }
 
 //---------------------------------------------------------------------------------------------------- TESTS


### PR DESCRIPTION
## What
`AudioState` is cleared before a `Collection` reset as the key's inside it will become invalid afterwards.

But, using the `Map`, we can convert `AudioState` to a `str` form, then _attempt_ to convert it back to key form such that `AudioState` can continue even in the face of a `Collection` reset.

This means the queue can continue to play (the same songs) even after a `Collection` reset, which is cool.

## Todo
- invalid keys must be pruned
- valid keys must be converted `Key` -> `Arc<str>` -> `Key`
- previous state must be restored as much as possible 