### PR TITLE
Queue - Random `Artist/Album/Song` button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Types of changes:
 
 
 # Festival GUI Unreleased
+## Added
+* Queue tab - random artist/album/song buttons ([#63](https://github.com/hinto-janai/festival/pull/63))
 
 
 ---


### PR DESCRIPTION
Adds button to the `Queue` tab that:
- Primary click: clear queue, add and play random `Artist/Album/Song`
- Secondary click: append random `Artist/Album/Song` to back of queue