### PR TITLE
`cargo upgrade` (selectively)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,16 +895,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "winapi",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1156,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "const_format"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c990efc7a285731f9a4378d81aff2f0e85a2c8781a05ef0f8baa8dac54d0ff48"
+checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
 dependencies = [
  "const_format_proc_macros",
  "konst",
@@ -1166,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "const_format_proc_macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e026b6ce194a874cb9cf32cd5772d1ef9767cc8fcb5765948d74f37a9d8b2bf6"
+checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1600,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "disk"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039d420f86ddbd20d71ae74c7b50e0b5ddf54b9d80dee39185dd82b61f94078f"
+checksum = "b8ac36e99d95455fef38221558f8a37cd381158dd54c6966df18d6c40b0408b5"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -1612,14 +1612,14 @@ dependencies = [
  "directories",
  "flate2",
  "libc",
- "memmap2 0.7.1",
+ "memmap2 0.9.0",
  "once_cell",
  "paste",
  "seq-macro",
  "serde",
  "serde_json",
  "serde_plain",
- "toml_edit",
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
@@ -1917,9 +1917,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
 dependencies = [
  "humantime",
  "is-terminal",
@@ -2083,7 +2083,7 @@ dependencies = [
  "serde_json",
  "shukusai",
  "strum",
- "toml_edit",
+ "toml_edit 0.21.0",
  "ureq",
  "urlencoding",
  "zeroize",
@@ -2156,7 +2156,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-util",
- "toml_edit",
+ "toml_edit 0.21.0",
  "urlencoding",
  "walkdir",
  "zeroize",
@@ -2177,9 +2177,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -3225,9 +3225,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libdbus-sys"
@@ -3378,9 +3378,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memmap2"
@@ -3402,9 +3402,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
+checksum = "deaba38d7abf1d4cca21cc89e932e542ba2b9258664d2a9ef0e61512039c9375"
 dependencies = [
  "libc",
 ]
@@ -4239,7 +4239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.14",
 ]
 
 [[package]]
@@ -4430,25 +4430,25 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.3"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -4456,6 +4456,12 @@ name = "regex-syntax"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "renderdoc-sys"
@@ -4778,9 +4784,9 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.186"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f5db24220c009de9bd45e69fb2938f4b6d2df856aa9304ce377b3180f83b7c1"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
  "serde_derive",
 ]
@@ -4796,9 +4802,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.186"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad697f7e0b65af4983a4ce8f56ed5b357e8d3c36651bf6a7e13639c17b8e670"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4807,9 +4813,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.105"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
@@ -4819,9 +4825,9 @@ dependencies = [
 
 [[package]]
 name = "serde_plain"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6018081315db179d0ce57b1fe4b62a12a0028c9cf9bbef868c9cf477b3c34ae"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
 dependencies = [
  "serde",
 ]
@@ -4839,9 +4845,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
 ]
@@ -5398,7 +5404,7 @@ dependencies = [
  "fnv",
  "once_cell",
  "plist",
- "regex-syntax",
+ "regex-syntax 0.7.4",
  "serde",
  "serde_json",
  "thiserror",
@@ -5652,14 +5658,14 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.14",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
@@ -5669,6 +5675,19 @@ name = "toml_edit"
 version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+dependencies = [
+ "indexmap 2.0.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
  "indexmap 2.0.0",
  "serde",
@@ -5947,9 +5966,9 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,36 +32,36 @@ opt-level = 1
 ### Personal.
 shukusai = { version = "0.0.6",  path = "shukusai" }
 benri    = { version = "0.1.12", features = ["log"] }
-disk     = { version = "0.1.20", features = ["bincode2", "empty", "toml", "plain", "json", "bytesize"] }
-readable = { version = "0.8.12",  features = ["ignore_nan_inf", "serde", "bincode"] }
+disk     = { version = "0.1.21", features = ["bincode2", "empty", "toml", "plain", "json", "bytesize"] }
+readable = { version = "0.8.13",  features = ["ignore_nan_inf", "serde", "bincode"] }
 json-rpc = { version = "0.1.2", path = "external/json-rpc" }
 rpc      = { version = "1.0.0", path = "rpc/" }
 
 ### Regular libraries.
-anyhow       = { version = "1.0.71" }
+anyhow       = { version = "1.0.75" }
 bincode      = { version = "2.0.0-rc.3", features = ["serde"] }
-clap         = { version = "4", features = ["derive"] }
+clap         = { version = "4.4.8", features = ["derive"] }
 crossbeam    = { version = "0.8.2", features = ["crossbeam-channel"] }
-const_format = { version = "0.2.31", features = ["rust_1_51", "assertcp", "rust_1_64"] }
-compact_str  = { version = "0.7.0" }
+const_format = { version = "0.2.32", features = ["rust_1_51", "assertcp", "rust_1_64"] }
+compact_str  = { version = "0.7.1" }
 dirs         = { version = "5.0.1" }
-env_logger   = { version = "0.10.0" }
-image        = { version = "0.24.6" }
-log          = { version = "0.4.18", features = ["serde"] }
-libc         = { version = "0.2.147" }
-memmap2      = { version = "0.6.2" }
+env_logger   = { version = "0.10.1" }
+image        = { version = "0.24.7" }
+log          = { version = "0.4.20", features = ["serde"] }
+libc         = { version = "0.2.150" }
+memmap2      = { version = "0.9.0" }
 once_cell    = { version = "1.18.0" }
-open         = { version = "4.2.0" }
-paste        = { version = "1.0.12" }
+open         = { version = "5.0.0" }
+paste        = { version = "1.0.14" }
 rand         = { version = "0.8.5", features = ["small_rng"] }
-serde        = { version = "1.0.163", features = ["derive", "rc"] }
-serde_bytes  = { version = "0.11.9" }
-serde_json   = { version = "1.0.100", features = ["preserve_order"] }
-seq-macro    = { version = "0.3.3" }
+serde        = { version = "1.0.192", features = ["derive", "rc"] }
+serde_bytes  = { version = "0.11.12" }
+serde_json   = { version = "1.0.108", features = ["preserve_order"] }
+seq-macro    = { version = "0.3.5" }
 strum        = { version = "0.25.0", features = ["derive"] }
-termimad     = { version = "0.23.2" }
-toml_edit    = { version = "0.19.14" }
-walkdir      = { version = "2.3.3" }
+termimad     = { version = "0.26.1" }
+toml_edit    = { version = "0.21.0", features = ["serde"] }
+walkdir      = { version = "2.4.0" }
 zeroize      = { version = "1.6.0", features = ["std", "zeroize_derive"] }
 zip          = { version = "0.6.6" }
 


### PR DESCRIPTION
Updates (patch):
- `anyhow`
- `const_format`
- `compact_str`
- `disk`
- `env_logger`
- `image`
- `log`
- `libc`
- `paste`
- `serde`
- `serde_bytes`
- `serde_json`
- `seq-macro`

Upgrades (major/minor):
- `memmap2`
- `toml_edit`
- `termimad`
- `open`
- `walkdir`

Across the workspace.

`readable` is staying at `0.8.x` since there are too many changes afterwards - breaks a ton of code - might break schema - etc etc.