### PR TITLE
audio: tighten decode loop

### DIFF
--- a/shukusai/src/audio/output.rs
+++ b/shukusai/src/audio/output.rs
@@ -110,7 +110,7 @@ mod output {
 			}
 
 			// Create PulseAudio buffer attribute.
-			const T_LENGTH: u32 = 16384;
+			const T_LENGTH: u32 = 8192;
 			let pa_buf_attr = pulse::def::BufferAttr {
 				// This reduces the audio buffer we hold.
 				//
@@ -119,7 +119,7 @@ mod output {
 				// via Festival since we flush the samples that
 				// haven't been played yet.
 				//
-				// This sets it to around 50ms~.
+				// This sets it to around 25ms~.
 				tlength: T_LENGTH,
 
 				maxlength: std::u32::MAX,
@@ -272,7 +272,7 @@ mod output {
 			};
 
 			// Create a ring buffer with a capacity for up-to 50ms of audio.
-			let ring_len = ((50 * config.sample_rate.0 as usize) / 1000) * num_channels;
+			let ring_len = ((25 * config.sample_rate.0 as usize) / 1000) * num_channels;
 
 			let ring_buf = SpscRb::new(ring_len);
 			let (ring_buf_producer, ring_buf_consumer) = (ring_buf.producer(), ring_buf.consumer());

--- a/shukusai/src/audio/output.rs
+++ b/shukusai/src/audio/output.rs
@@ -31,7 +31,7 @@ pub(crate) trait Output: Sized {
 	fn dummy() -> std::result::Result<Self, AudioOutputError> {
 		let spec = SignalSpec {
 			// INVARIANT: Must be non-zero.
-			rate: 48_000,
+			rate: 44_100,
 
 			// INVARIANT: Must be a valid entry in the below map `match`.
 			channels: Channels::FRONT_LEFT,


### PR DESCRIPTION
This lowers the amount of leeway `Audio` has in the decode loop for things that are _not_ decoding/playback.

It will sleep/recv for less time, giving a bit more leeway for audio samples to be processed.

The audio device/server buffer has also been lowered from `50ms` -> `25ms`. This makes pausing (which implicitly `flush()`'s) a faster operation as there are less samples to flush.