### PR TITLE
audio: apply volume transformation after resample

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "audio_thread_priority"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e6839a6e8e72338137b3126c7fe61af95b9acc3076d2b7109696f808d1234f"
+dependencies = [
+ "cfg-if",
+ "dbus 0.6.5",
+ "libc",
+ "log",
+ "mach",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,6 +1513,16 @@ checksum = "8d7439c3735f405729d52c3fbbe4de140eaf938a1fe47d227c27f8254d4302a5"
 
 [[package]]
 name = "dbus"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48b5f0f36f1eebe901b0e6bee369a77ed3396334bf3f09abd46454a576f71819"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+]
+
+[[package]]
+name = "dbus"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
@@ -1514,7 +1538,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a4c83437187544ba5142427746835061b330446ca8902eabd70e4afb8f76de0"
 dependencies = [
- "dbus",
+ "dbus 0.9.7",
 ]
 
 [[package]]
@@ -3380,6 +3404,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4898,6 +4931,7 @@ version = "0.0.6"
 dependencies = [
  "anyhow",
  "arrayvec",
+ "audio_thread_priority",
  "benri",
  "bincode 2.0.0-rc.3",
  "compact_str",
@@ -4914,7 +4948,6 @@ dependencies = [
  "image",
  "infer",
  "jpeg-encoder",
- "libc",
  "libpulse-binding",
  "libpulse-simple-binding",
  "log",
@@ -5088,7 +5121,7 @@ dependencies = [
  "block",
  "cocoa",
  "core-graphics",
- "dbus",
+ "dbus 0.9.7",
  "dbus-crossroads",
  "dispatch",
  "objc",


### PR DESCRIPTION
Should result in (less) lossy output `f32`'s...?

`AudioOutput::write()` is now responsible for volume transformation instead of `Audio` applying it before calling `write()`.

This includes some perf (reused local storage instead of `AudioBuffer::new()` every `write()`) and bug fixes too.