### PR TITLE
resampler: resize output buf instead of interleaved sample buf

### DIFF
--- a/shukusai/src/audio/output.rs
+++ b/shukusai/src/audio/output.rs
@@ -364,11 +364,15 @@ mod output {
 			self.samples.extend_from_slice(samples);
 
 			// Taken from: https://docs.rs/symphonia-core/0.5.3/src/symphonia_core/audio.rs.html#680-692
-			for plane in self.samples.chunks_mut(capacity) {
-				for sample in &mut plane[0..frames] {
-					*sample = *sample * volume;
-				}
-			}
+			//
+			// Changed to use iterators over indexing.
+			self.samples
+				.chunks_mut(capacity)
+				.for_each(|plane| {
+					plane
+						.iter_mut()
+						.for_each(|sample| *sample *= volume)
+				});
 
 			let mut samples = self.samples.as_mut_slice();
 

--- a/shukusai/src/audio/resampler.rs
+++ b/shukusai/src/audio/resampler.rs
@@ -60,7 +60,11 @@ where
 		// Interleave the planar samples from Rubato.
 		let num_channels = self.output.len();
 
-		self.interleaved.resize(num_channels * self.output[0].len(), T::MID);
+		let len = self.interleaved.len() / num_channels;
+		self.output
+			.iter_mut()
+			.filter(|channel| channel.len() < len)
+			.for_each(|channel| channel.resize(len, 0.0));
 
 		for (i, frame) in self.interleaved.chunks_exact_mut(num_channels).enumerate() {
 			for (ch, s) in frame.iter_mut().enumerate() {


### PR DESCRIPTION
Sometimes, the interleaved sample buffer after resampling ends up being a few samples longer than `channel_count * samples_in_channel` for... reasons unknown.

Before, the fix to make sure indexing panics didn't happen was to shorten the interleaved buffer so it wouldn't overflow.

Now, the output buffer is _extended_ such that it can fit these mysterious extra samples.