### PR TITLE
resampler: revert 496bf41427e2ac70f4f3d06d19f90c90152be862

### DIFF
--- a/shukusai/src/audio/resampler.rs
+++ b/shukusai/src/audio/resampler.rs
@@ -60,11 +60,7 @@ where
 		// Interleave the planar samples from Rubato.
 		let num_channels = self.output.len();
 
-		let len = self.interleaved.len() / num_channels;
-		self.output
-			.iter_mut()
-			.filter(|channel| channel.len() < len)
-			.for_each(|channel| channel.resize(len, 0.0));
+		self.interleaved.resize(num_channels * self.output[0].len(), T::MID);
 
 		for (i, frame) in self.interleaved.chunks_exact_mut(num_channels).enumerate() {
 			for (ch, s) in frame.iter_mut().enumerate() {


### PR DESCRIPTION
This reverts https://github.com/hinto-janai/festival/commit/496bf41427e2ac70f4f3d06d19f90c90152be862.

The old code was actually correct, we're creating and returning the interleaved from the `self.output`, so `self.interleaved` should match the output length, not the other way around.

The reason panics happened before was probably due to the interleaved having an old length from a previous resample.

Well, Festival GUI v1.3.2 is already out there so ... next time.