### PR TITLE
Find & restore state on `Collection` reset

### DIFF
--- a/gui/src/data/gui.rs
+++ b/gui/src/data/gui.rs
@@ -1,6 +1,7 @@
 //---------------------------------------------------------------------------------------------------- Use
 use crate::data::{
 	State,
+	StateRestore,
 	Settings,
 	DebugInfo,
 };
@@ -56,6 +57,8 @@ pub struct Gui {
 	pub state: State,
 	/// `GUI` settings (old).
 	pub og_state: State,
+	/// In-between `Collection`-reset state to be potentially carried over.
+	pub state_restore: StateRestore,
 
 	//-------------------------------------------------- Ephemeral State.
 	// These are quick one-off fields that mostly

--- a/gui/src/func/init.rs
+++ b/gui/src/func/init.rs
@@ -248,6 +248,7 @@ impl crate::data::Gui {
 			// `GUI` state.
 			og_state: state.clone(),
 			state,
+			state_restore: Default::default(),
 
 			// AudioState.
 			audio_state: AudioState::new(),


### PR DESCRIPTION
This adds some "in-between Collection reset" state such that the keys of currently selected albums/artists can be recovered after the reset, akin to the `AudioState` restore functionality.

The currently selected tab also stays after resets.