### PR TITLE
Set `festivald` & `festival-cli` as unmaintained

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-#        pkg: [festival-gui, festivald, festival-cli]
         pkg: [festival-gui]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         if [ "$RUNNER_OS" == "Linux" ]; then
           sudo apt update
-          sudo apt install -y libgtk-3-dev libasound2-dev libjack-dev libpulse-dev
+          sudo apt install -y libgtk-3-dev libasound2-dev libjack-dev libpulse-dev libfuse2
         elif [ "$RUNNER_OS" == "macOS" ]; then
           rustup target add aarch64-apple-darwin
         fi

--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        pkg: [gui,daemon,cli]
+        pkg: [gui]
 
     steps:
     - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,7 +375,7 @@ dependencies = [
  "polling",
  "rustix 0.37.23",
  "slab",
- "socket2 0.4.9",
+ "socket2",
  "waker-fn",
 ]
 
@@ -1194,15 +1194,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
-name = "coolor"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce3e41909f18d5860fe1e6699651fcca2cb2576ee68c6984c93c2b26d059ea"
-dependencies = [
- "crossterm",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,31 +1401,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
-dependencies = [
- "bitflags 1.3.2",
- "crossterm_winapi",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -2078,41 +2044,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "festival-cli"
-version = "1.0.0"
-dependencies = [
- "anyhow",
- "base64 0.21.2",
- "benri",
- "bincode 2.0.0-rc.3",
- "clap 4.4.8",
- "compact_str",
- "const_format",
- "crossbeam",
- "dirs",
- "disk",
- "env_logger",
- "hex",
- "http",
- "json-rpc",
- "log",
- "memmap2 0.9.0",
- "once_cell",
- "open",
- "readable",
- "rpc",
- "serde",
- "serde_json",
- "shukusai",
- "strum",
- "toml_edit 0.21.0",
- "ureq",
- "urlencoding",
- "zeroize",
- "zip",
-]
-
-[[package]]
 name = "festival-gui"
 version = "1.4.0"
 dependencies = [
@@ -2142,46 +2073,6 @@ dependencies = [
  "strum",
  "windows 0.48.0",
  "winres",
- "zip",
-]
-
-[[package]]
-name = "festivald"
-version = "1.0.0"
-dependencies = [
- "anyhow",
- "benri",
- "bincode 2.0.0-rc.3",
- "clap 4.4.8",
- "compact_str",
- "const_format",
- "crossbeam",
- "dirs",
- "disk",
- "http",
- "hyper",
- "hyper-staticfile",
- "image",
- "json-rpc",
- "log",
- "memmap2 0.9.0",
- "mime",
- "once_cell",
- "open",
- "rand",
- "readable",
- "rpc",
- "serde",
- "serde_json",
- "shukusai",
- "strum",
- "tokio",
- "tokio-native-tls",
- "tokio-util",
- "toml_edit 0.21.0",
- "urlencoding",
- "walkdir",
- "zeroize",
  "zip",
 ]
 
@@ -2305,15 +2196,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,17 +2223,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-macro"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.32",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2371,7 +2242,6 @@ checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-core",
  "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -2679,25 +2549,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap 1.9.3",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2797,93 +2648,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
-dependencies = [
- "bytes",
- "http",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-range"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
-
-[[package]]
-name = "httparse"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "hyper"
-version = "0.14.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.4.9",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper-staticfile"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318ca89e4827e7fe4ddd2824f52337239796ae8ecc761a663324407dc3d8d7e7"
-dependencies = [
- "futures-util",
- "http",
- "http-range",
- "httpdate",
- "hyper",
- "mime_guess",
- "percent-encoding",
- "rand",
- "tokio",
- "url",
- "winapi",
-]
 
 [[package]]
 name = "iana-time-zone"
@@ -3159,14 +2927,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json-rpc"
-version = "0.1.2"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "khronos-egl"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3225,29 +2985,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a53776d271cfb873b17c618af0298445c88afc52837f3e948fa3fafd131f449"
 dependencies = [
  "arrayvec",
-]
-
-[[package]]
-name = "lazy-regex"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d12be4595afdf58bd19e4a9f4e24187da2a66700786ff660a418e9059937a4c"
-dependencies = [
- "lazy-regex-proc_macros",
- "once_cell",
- "regex",
-]
-
-[[package]]
-name = "lazy-regex-proc_macros"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bcd58e6c97a7fcbaffcdc95728b393b8d98933bfadad49ed4097845b57ef0b"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.32",
 ]
 
 [[package]]
@@ -3523,15 +3260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimad"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c4610f430e49b882fcaad0186134150d4d74fc76080b0a61f7000460c2e268"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3592,24 +3320,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -3963,60 +3673,6 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
-]
-
-[[package]]
-name = "openssl"
-version = "0.10.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729b745ad4a5575dd06a3e1af1414bd330ee561c01b3899eb584baeaa8def17e"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.32",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-src"
-version = "111.27.0+1.1.1v"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e8f197c82d7511c5b014030c9b1efeda40d7d5f99d23b4ceed3524a5e63f02"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866b5f16f90776b9bb8dc1e1802ac6f0513de3a7a7465867bfbc563dc737faac"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -4599,37 +4255,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rpc"
-version = "1.0.0"
-dependencies = [
- "anyhow",
- "base64 0.21.2",
- "benri",
- "bincode 2.0.0-rc.3",
- "clap 4.4.8",
- "compact_str",
- "const_format",
- "crossbeam",
- "disk",
- "hex",
- "image",
- "json-rpc",
- "log",
- "once_cell",
- "paste",
- "rand",
- "readable",
- "seq-macro",
- "serde",
- "serde_json",
- "sha2",
- "shukusai",
- "strum",
- "termimad",
- "zeroize",
-]
-
-[[package]]
 name = "rubato"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4755,15 +4380,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
-dependencies = [
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4796,29 +4412,6 @@ dependencies = [
  "memmap2 0.5.10",
  "smithay-client-toolkit",
  "tiny-skia",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-foundation-sys 0.8.4",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
-dependencies = [
- "core-foundation-sys 0.8.4",
- "libc",
 ]
 
 [[package]]
@@ -4988,17 +4581,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-mio"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5087,27 +4669,6 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "socks"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
-dependencies = [
- "byteorder",
  "libc",
  "winapi",
 ]
@@ -5499,22 +5060,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termimad"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3d19056c90eb12f23da61808c9f8c22b7d031bb5d50400b726ecf2d9718e73"
-dependencies = [
- "coolor",
- "crossbeam",
- "crossterm",
- "lazy-regex",
- "minimad",
- "serde",
- "thiserror",
- "unicode-width",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5630,64 +5175,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tokio"
-version = "1.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
-dependencies = [
- "backtrace",
- "bytes",
- "libc",
- "mio",
- "num_cpus",
- "parking_lot",
- "pin-project-lite",
- "signal-hook-registry",
- "socket2 0.5.3",
- "tokio-macros",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.32",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-util",
- "hashbrown 0.12.3",
- "pin-project-lite",
- "slab",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5744,12 +5231,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-service"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
-
-[[package]]
 name = "tracing"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5790,12 +5271,6 @@ dependencies = [
  "num-integer",
  "strength_reduce",
 ]
-
-[[package]]
-name = "try-lock"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "ttf-parser"
@@ -5915,13 +5390,9 @@ dependencies = [
  "base64 0.21.2",
  "flate2",
  "log",
- "native-tls",
  "once_cell",
  "rustls",
  "rustls-webpki 0.100.2",
- "serde",
- "serde_json",
- "socks",
  "url",
  "webpki-roots",
 ]
@@ -5936,12 +5407,6 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "usvg"
@@ -5974,12 +5439,6 @@ name = "uuid"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -6019,15 +5478,6 @@ checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
 ]
 
 [[package]]
@@ -6807,26 +6257,6 @@ name = "zerocopy-derive"
 version = "0.7.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2f140bda219a26ccc0cdb03dba58af72590c53b22642577d88a927bc5c87d6b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.32",
-]
-
-[[package]]
-name = "zeroize"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,6 @@
 members = [
 	"shukusai",
 	"gui",
-	"rpc",
-	"daemon",
-	"cli",
 ]
 exclude = [
 	"web",
@@ -34,8 +31,6 @@ shukusai = { version = "0.0.6",  path = "shukusai" }
 benri    = { version = "0.1.12", features = ["log"] }
 disk     = { version = "0.1.21", features = ["bincode2", "empty", "toml", "plain", "json", "bytesize"] }
 readable = { version = "0.8.13",  features = ["ignore_nan_inf", "serde", "bincode"] }
-json-rpc = { version = "0.1.2", path = "external/json-rpc" }
-rpc      = { version = "1.0.0", path = "rpc/" }
 
 ### Regular libraries.
 anyhow       = { version = "1.0.75" }
@@ -59,10 +54,8 @@ serde_bytes  = { version = "0.11.12" }
 serde_json   = { version = "1.0.108", features = ["preserve_order"] }
 seq-macro    = { version = "0.3.5" }
 strum        = { version = "0.25.0", features = ["derive"] }
-termimad     = { version = "0.26.1" }
 toml_edit    = { version = "0.21.0", features = ["serde"] }
 walkdir      = { version = "2.4.0" }
-zeroize      = { version = "1.6.0", features = ["std", "zeroize_derive"] }
 zip          = { version = "0.6.6" }
 
 ### HACK:

--- a/README.md
+++ b/README.md
@@ -11,18 +11,8 @@ https://github.com/hinto-janai/festival/assets/101352116/586e37e7-762d-4dc6-a9c4
 
 </div>
 
-## Frontends
-Festival comes in a few different forms.
-
-Click on the frontend to see more information.
-
-| Frontend | Description | Released | Documentation |
-|----------|-------------|----------|---------------|
-| [`festival-gui`](https://github.com/hinto-janai/festival/tree/main/gui) | GUI        | 🟢 2023-06-28 | https://docs.festival.pm/gui
-| [`festivald`](https://github.com/hinto-janai/festival/tree/main/daemon) | Daemon     | 🟢 2023-08-24 | https://docs.festival.pm/daemon
-| [`festival-cli`](https://github.com/hinto-janai/festival/tree/main/cli) | CLI client | 🟢 2023-08-24 | https://docs.festival.pm/cli
-| [`festival-web`](https://github.com/hinto-janai/festival/tree/main/web) | Web server | 🔴            | https://docs.festival.pm/web
-| [`festival-tui`](https://github.com/hinto-janai/festival/tree/main/tui) | TUI        | 🔴            | https://docs.festival.pm/tui
+## Documentation
+See documentation at https://docs.festival.pm/gui.
 
 ## Comparison
 For a comparison between Festival and other music players, see [`comparison/`](https://github.com/hinto-janai/festival/tree/main/comparison/README.md).
@@ -40,25 +30,7 @@ You also need to clone the `submodules` that include patched libraries found in 
 git clone --recursive https://github.com/hinto-janai/festival
 ```
 
-Built binaries are found in `target/release/${FRONTEND_BINARY_NAME}` by default.
-
-The repo is a workspace, with some packages shared between all `Frontend`'s, including the internals: [`shukusai`](https://github.com/hinto-janai/festival/tree/main/shukusai).
-
-To build one of the `Frontend`'s, you must pass the `--package <FRONTEND>` option.
-
-Each frontend's release has a git tag, so to build the latest _stable_ `festival-gui`:
-```bash
-git checkout gui-v1.4.0
-cargo build --release --package festival-gui
-```
-
-The [`x.sh`](https://github.com/hinto-janai/festival/tree/main/x.sh) script at the repo root is a convenience script for linting/testing/building all `Festival` frontends.
-
-For example, to build all packages in `--release` mode, from the current commit:
-```bash
-./x.sh build
-```
-Use `./x.sh help` to see more options.
+The built binary is found in `target/release/festival[.exe]` by default.
 
 ---
 
@@ -70,31 +42,14 @@ Use `./x.sh help` to see more options.
 ---
 
 The pre-compiled Linux binaries are built on Ubuntu 20.04, you'll need these packages to build:
-```
-# Shared packages.
-sudo apt install build-essential pkg-config libdbus-1-dev libpulse-dev
-
-# Only for `festival-gui`.
-sudo apt install libgtk-3-dev
-
-# Only for `festivald` & `festival-cli`.
-sudo apt install libssl-dev
+```bash
+sudo apt install build-essential pkg-config libdbus-1-dev libpulse-dev libgtk-3-dev
 ```
 
-To build [`festival-gui`](https://github.com/hinto-janai/festival/tree/main/gui):
+To build the latest _stable_ release:
 ```bash
 git checkout gui-v1.4.0
-cargo build --release --package festival-gui
-```
-To build [`festivald`](https://github.com/hinto-janai/festival/tree/main/daemon):
-```bash
-git checkout daemon-v1.0.0
-cargo build --release --package festivald
-```
-To build [`festival-cli`](https://github.com/hinto-janai/festival/tree/main/cli):
-```bash
-git checkout cli-v1.0.0
-cargo build --release --package festival-cli
+cargo build --release
 ```
 
 ---
@@ -106,20 +61,10 @@ cargo build --release --package festival-cli
 
 ---
 
-To build [`festival-gui`](https://github.com/hinto-janai/festival/tree/main/gui):
+To build the latest _stable_ release:
 ```bash
 git checkout gui-v1.4.0
-cargo build --release --package festival-gui
-```
-To build [`festivald`](https://github.com/hinto-janai/festival/tree/main/daemon):
-```bash
-git checkout daemon-v1.0.0
-cargo build --release --package festivald
-```
-To build [`festival-cli`](https://github.com/hinto-janai/festival/tree/main/cli):
-```bash
-git checkout cli-v1.0.0
-cargo build --release --package festival-cli
+cargo build --release
 ```
 
 ---
@@ -131,10 +76,10 @@ cargo build --release --package festival-cli
 
 ---
 
-To build [`festival-gui`](https://github.com/hinto-janai/festival/tree/main/gui):
+To build the latest _stable_ release:
 ```bash
 git checkout gui-v1.4.0
-cargo build --release --package festival-gui
+cargo build --release
 ```
 
 There is a [`build.rs`](https://github.com/hinto-janai/festival/blob/main/gui/build.rs) file in `gui/` solely for Windows-specific things:
@@ -143,16 +88,6 @@ There is a [`build.rs`](https://github.com/hinto-janai/festival/blob/main/gui/bu
 2. It sets some miscellaneous metadata
 3. It statically links `VCRUNTIME140.dll` (the binary will not be portable without this)
 
-To build [`festivald`](https://github.com/hinto-janai/festival/tree/main/daemon):
-```bash
-git checkout daemon-v1.0.0
-cargo build --release --package festivald
-```
-To build [`festival-cli`](https://github.com/hinto-janai/festival/tree/main/cli):
-```bash
-git checkout cli-v1.0.0
-cargo build --release --package festival-cli
-```
 
 ---
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,3 +1,8 @@
+# ⚠️ Unmaintained
+Starting from `2024-02-15`, `festival-cli` is no longer maintained.
+
+See https://github.com/hinto-janai/festival/pull/89 for more info.
+
 # `festival-cli`
 `festival-cli` is a [`JSON-RPC 2.0`](https://www.jsonrpc.org/specification) client for [`festivald`](https://docs.festival.pm/daemon).
 

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -1,3 +1,8 @@
+# ⚠️ Unmaintained
+Starting from `2024-02-15`, `festivald` is no longer maintained.
+
+See https://github.com/hinto-janai/festival/pull/89 for more info.
+
 # `festivald`
 [`Festival`](https://festival.pm) [daemon](https://en.wikipedia.org/wiki/Daemon_(computing)).
 

--- a/shukusai/Cargo.toml
+++ b/shukusai/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 ]
 
 [features]
-default = ["panic"]
+default = ["panic", "gui"]
 panic   = []
 gui     = ["egui", "egui_extras", "epaint"]
 daemon  = []


### PR DESCRIPTION
## Why
[`festivald`](https://github.com/hinto-janai/festival/tree/main/daemon) and [`festival-cli`](https://github.com/hinto-janai/festival/tree/main/cli) were both created because "why not?".

A majority of the [internal code](https://github.com/hinto-janai/festival/tree/main/shukusai) was already written and explicitly created to be usable with multiple frontends.

Nothing is wrong with either of them, but:
1. I do not use them personally
2. They make making changes to the internals difficult

This prevents changes from occurring in the main frontend: [`festival-gui`](https://github.com/hinto-janai/festival/tree/main/gui). 

## What now
Both `festivald` & `festival-cli` will be officially "unmaintained".

The only released `v1.0.0` binaries will still work, but they will not receive updates.

The code for both these projects will continue to exist in the repository, and will still be able to be compiled with:
```bash
# festivald
git checkout daemon-v1.0.0
cargo build --release --package festivald

# festival-cli
git checkout cli-v1.0.0
cargo build --release --package festival-cli
```

## Future
I have plans for separating major parts of `shukusai` (the internals) into many [different](https://github.com/hinto-janai/sansan) libraries.

`festivald` & `festival-cli` may reappear, using these new libraries in a `v2.0.0` when I eventually write them... someday. 